### PR TITLE
Prevent Unresponsive settings dialog from being duplicated

### DIFF
--- a/static/unresponsive.js
+++ b/static/unresponsive.js
@@ -116,7 +116,7 @@ function createSettingsDiv(){
 	}
 	
 	mainDiv = element($('body')[0], "div", ["account","unresponsive-dialog"]);
-	mainDiv.id = '#unresponsive-setting-dialog';
+	mainDiv.id = 'unresponsive-setting-dialog';
 	modalDiv = element($('body')[0], "div", "unresponsive-modal");
 	modalDiv.addEventListener("click", function(){$(modalDiv).hide(); $(settingsDiv).hide();});
 	


### PR DESCRIPTION
currently the dialog for unresponsive settings is duplicated on every navigation event, this is because it's creating the dialog with an invalid ID.

Element Ids can't contain the `#` character as that is the CSS "element ID" selector.

so the code never figures out that it already created the dialog.

you could also skip the DOM search entirely and test for a truthy value of `settingsDiv` and return `settingsDiv` if it's truthy, that's also an option.

;-)
